### PR TITLE
debug: Add exception and resourceloader, remove dupe wgDebugLogFile

### DIFF
--- a/settings.d/00-debug.php-example
+++ b/settings.d/00-debug.php-example
@@ -37,11 +37,12 @@ $wgShowExceptionDetails = true;
 //
 
 $mwLogDir = __DIR__ . '/../logs';
-$wgDebugLogFile = "$mwLogDir/mediawiki-debug.log";
+$wgDebugLogFile = "$mwLogDir/debug.log";
 $wgDBerrorLog = "$mwLogDir/dberror.log";
 // $wgRateLimitLog = "$mwLogDir/ratelimit.log";
-$wgDebugLogFile = "$mwLogDir/debug.log";
-// $wgDebugLogGroups['somegroup'] = "$mwLogDir/debug-somegroup.log"
+$wgDebugLogGroups['exception'] = "$mwLogDir/exception.log";
+$wgDebugLogGroups['resourceloader'] = "$mwLogDir/resourceloader.log";
+// $wgDebugLogGroups['somegroup'] = "$mwLogDir/somegroup.log"
 
 
 // ResourceLoader-specific


### PR DESCRIPTION
- Remove duplicate assignment of `$wgDebugLogFile`.
- Filter group 'exception' and 'resourceloader' by default.
- Remove 'debug-' prefix from commented out example.
